### PR TITLE
Kernel#system calls avoid shell

### DIFF
--- a/bin/helphelp
+++ b/bin/helphelp
@@ -49,9 +49,13 @@ end
 
 if do_pull
   puts "Updating git repository..."
-  branch_cmd = branch ? "git fetch --all; git checkout #{branch} &&" : ""
-  cmd = "cd #{input_repo}; #{branch_cmd} git pull"
-  system cmd
+  Dir.chdir input_repo do
+    if branch
+      system 'git', 'fetch', '--all'
+      system 'git', 'checkout', branch
+    end
+    system 'git', 'pull'
+  end
 end
 
 puts "Reading repository #{input_repo}"

--- a/lib/output.rb
+++ b/lib/output.rb
@@ -110,7 +110,7 @@ class Output
         size = "#{@content_width}x5000"
         FileUtils.cp input, output
         cmd = ["mogrify", "-resize", size, output]
-        STDERR.puts "Resize picture: #{cmd.join ' '}"
+        STDERR.puts "Resize image: #{output} -> #{size}"
         system *cmd
       when /.*\.xml$/
         FileUtils.cp "#{input_path}/#{entry}", "#{output_path}/#{entry}"

--- a/lib/output.rb
+++ b/lib/output.rb
@@ -1,3 +1,5 @@
+require 'fileutils'
+
 class Output
 
   def initialize input_repo
@@ -20,8 +22,9 @@ class Output
         Dir::mkdir public_dir
       end
 
-      cmd = "cp #{public_source_dir}/* #{public_dir}"
-      system cmd
+      Dir.glob "#{public_source_dir}/*" do |path|
+        FileUtils.cp path, public_dir
+      end
     end
 
     @input_path = Array.new
@@ -102,14 +105,15 @@ class Output
           page.output_file = output_path + "/" + output_file_name
         end
       when /.*\.png$/
-        cmd = "cp #{input_path}/#{entry} #{output_path}/#{entry}"
-        system cmd
-        cmd = "mogrify -resize #{@content_width}x5000 #{output_path}/#{entry}"
-        STDERR.puts "Resize picture: #{cmd}"
-        system cmd
+        input = "#{input_path}/#{entry}"
+        output = "#{output_path}/#{entry}"
+        size = "#{@content_width}x5000"
+        FileUtils.cp input, output
+        cmd = ["mogrify", "-resize", size, output]
+        STDERR.puts "Resize picture: #{cmd.join ' '}"
+        system *cmd
       when /.*\.xml$/
-        cmd = "cp #{input_path}/#{entry} #{output_path}/#{entry}"
-        system cmd
+        FileUtils.cp "#{input_path}/#{entry}", "#{output_path}/#{entry}"
       end
     end
   end


### PR DESCRIPTION
Kernel#system calls avoid shell

Kernel#system calls are done with a list of arguments instead
of a single string.  this way the code ends up using fork/exec
instead.
